### PR TITLE
feat: sort fully transparent colors along their opaque friends

### DIFF
--- a/color-sorter.js
+++ b/color-sorter.js
@@ -21,16 +21,6 @@ const sortFn = (a, b) => {
 	const colorA = convert(a)
 	const colorB = convert(b)
 
-	// Move fully transparent colors to the back and
-	// sort by A-Z if both colors are fully transparent
-	if (colorA.alpha === 0 || colorB.alpha === 0) {
-		if (colorA.alpha === colorB.alpha) {
-			return colorA.authored.toLowerCase().localeCompare(colorB.authored.toLowerCase())
-		}
-
-		return colorB.alpha - colorA.alpha
-	}
-
 	// Move grey-ish values to the back
 	if (
 		(colorA.saturation === 0 || colorB.saturation === 0) &&
@@ -57,9 +47,11 @@ const sortFn = (a, b) => {
 	}
 
 	// Sort by transparency, least transparent first
-	if (colorA.alpha !== colorB.alpha) {
-		return colorB.alpha - colorA.alpha
+	if (colorA.alpha === colorB.alpha) {
+		return colorA.authored.toLowerCase().localeCompare(colorB.authored.toLowerCase())
 	}
+
+	return colorB.alpha - colorA.alpha
 }
 
 module.exports = colors => colors.sort(sortFn)

--- a/test.js
+++ b/test.js
@@ -121,18 +121,18 @@ test('Grey-ish colors are sorted by Lightness, then by Alpha', t => {
 	const expected = [
 		'hsla(0, 0, 20%, 1)',
 		'hsla(0, 0, 10%, 1)',
-		'hsla(0, 0, 0, 0)',
-		'hsla(0, 0, 10%, 0)'
+		'hsla(0, 0, 10%, 0)',
+		'hsla(0, 0, 0, 0)'
 	]
 	const actual = colorSorter(colors)
 
 	t.deepEqual(actual, expected)
 })
 
-test('Fully transparent colors are shifted to the end', t => {
-	const colors = ['hsla(0, 0, 0, 0)', 'hsla(0, 0, 0, .5)', 'hsla(0, 0, 0, 1)']
+test('Fully transparent colors are sorted along their opaque companions', t => {
+	const colors = ['rgba(255, 0, 0, 0)', 'hsla(0, 100%, 50%, 0.1)', 'red']
 	const actual = colorSorter(colors)
-	const expected = ['hsla(0, 0, 0, 1)', 'hsla(0, 0, 0, .5)', 'hsla(0, 0, 0, 0)']
+	const expected = ['red', 'hsla(0, 100%, 50%, 0.1)', 'rgba(255, 0, 0, 0)']
 
 	t.deepEqual(actual, expected)
 })


### PR DESCRIPTION
Grouping all fully transparent colors together was impractical for Design System reviews. Colors with opacity 0 are often used to transition from/to, so they serve their own purpose. For this, it's easier to group them alongside the color(s) that they're going be tranformed into.