### PR TITLE
fix: do not bundle colorjs.io into dist

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,9 @@ export default defineConfig({
 		rollupOptions: {
 			// make sure to externalize deps that shouldn't be bundled
 			// into your library
-			external: [],
+			external: [
+				'colorjs.io/fn'
+			],
 		},
 	},
 	plugins: [


### PR DESCRIPTION
- drastically decreases install size
- allows consumers to override colorjs.io's version